### PR TITLE
Fix value of config.vm.box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "trusty64"
+  config.vm.box = "ubuntu/trusty64"
 
   config.vm.network :forwarded_port, guest: 80, host: 8001
   config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
The specified linux image (config.vm.box) is trusty64 and should be "ubuntu/trusty64"